### PR TITLE
feat: send booking notifications via SMTP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Database connection
+DATABASE_URL=
+
+# SMTP configuration
+SMTP_HOST=
+SMTP_PORT=
+SMTP_USER=
+SMTP_PASS=
+SMTP_FROM=

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "eslint-config-next": "^15.5.3",
         "lucide-react": "^0.544.0",
         "next": "^15.5.3",
+        "nodemailer": "^6.10.1",
         "pg": "^8.16.3",
         "postcss": "^8.5.6",
         "react": "^19.1.1",
@@ -4335,6 +4336,15 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.20.tgz",
       "integrity": "sha512-7gK6zSXEH6neM212JgfYFXe+GmZQM+fia5SsusuBIUgnPheLFBmIPhtFoAQRj8/7wASYQnbDlHPVwY0BefoFgA==",
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eslint-config-next": "^15.5.3",
     "lucide-react": "^0.544.0",
     "next": "^15.5.3",
+    "nodemailer": "^6.10.1",
     "pg": "^8.16.3",
     "postcss": "^8.5.6",
     "react": "^19.1.1",

--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { Pool } from 'pg'
+import { sendBookingEmail } from '@/lib/email'
+
+export const runtime = 'nodejs'
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL })
 
@@ -81,6 +84,8 @@ export async function POST(request: NextRequest) {
     ]
     const { rows } = await pool.query(insertQuery, values)
     const bookingRecord = mapRow(rows[0])
+
+    await sendBookingEmail(bookingRecord)
 
     return NextResponse.json({
       success: true,

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,49 @@
+import nodemailer from 'nodemailer'
+
+interface BookingRecord {
+  id: string
+  service: string
+  groupSize: number
+  meetingType: string
+  name: string
+  email: string
+  phone: string
+  date: string
+  time: string
+  location?: string
+}
+
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST,
+  port: Number(process.env.SMTP_PORT),
+  auth: {
+    user: process.env.SMTP_USER,
+    pass: process.env.SMTP_PASS
+  }
+})
+
+export async function sendBookingEmail(booking: BookingRecord) {
+  const locationInfo =
+    booking.meetingType === 'online'
+      ? 'Online Meeting'
+      : `In-Person at ${booking.location ?? ''}`
+
+  const html = `
+    <h2>New Booking Confirmation</h2>
+    <p><strong>Booking ID:</strong> ${booking.id}</p>
+    <p><strong>Service:</strong> ${booking.service}</p>
+    <p><strong>Date & Time:</strong> ${booking.date} at ${booking.time}</p>
+    <p><strong>Group Size:</strong> ${booking.groupSize}</p>
+    <p><strong>Meeting Type:</strong> ${locationInfo}</p>
+    <p><strong>Name:</strong> ${booking.name}</p>
+    <p><strong>Email:</strong> ${booking.email}</p>
+    <p><strong>Phone:</strong> ${booking.phone}</p>
+  `
+
+  await transporter.sendMail({
+    from: process.env.SMTP_FROM,
+    to: ['barackdanieljackisa@gmail.com', 'tibedenis02@gmail.com'],
+    subject: `New Booking - ${booking.id}`,
+    html
+  })
+}


### PR DESCRIPTION
## Summary
- add SMTP email utility and .env template
- send booking confirmation emails to internal addresses
- document required SMTP environment variables

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: interactive ESLint config prompt)

------
https://chatgpt.com/codex/tasks/task_e_68c2cea7f9d48333a590803e26540b85