### PR TITLE
Handle in-person bookings with location support

### DIFF
--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -15,6 +15,7 @@ async function init() {
         service TEXT NOT NULL,
         group_size INTEGER NOT NULL,
         meeting_type TEXT NOT NULL,
+        location TEXT,
         name TEXT NOT NULL,
         email TEXT NOT NULL,
         phone TEXT NOT NULL,
@@ -24,6 +25,7 @@ async function init() {
         status TEXT NOT NULL
       )
     `)
+    await pool.query('ALTER TABLE bookings ADD COLUMN IF NOT EXISTS location TEXT')
     initialized = true
   }
 }
@@ -34,6 +36,7 @@ function mapRow(row: any) {
     service: row.service,
     groupSize: row.group_size,
     meetingType: row.meeting_type,
+    location: row.location,
     name: row.name,
     email: row.email,
     phone: row.phone,
@@ -53,6 +56,10 @@ export async function POST(request: NextRequest) {
     const requiredFields = ['service', 'groupSize', 'meetingType', 'name', 'email', 'phone', 'date', 'time']
     const missingFields = requiredFields.filter(field => !booking[field])
 
+    if (booking.meetingType === 'in-person' && !booking.location) {
+      missingFields.push('location')
+    }
+
     if (missingFields.length > 0) {
       return NextResponse.json(
         { error: `Missing required fields: ${missingFields.join(', ')}` },
@@ -65,8 +72,8 @@ export async function POST(request: NextRequest) {
     const createdAt = new Date()
 
     const insertQuery = `
-      INSERT INTO bookings (id, service, group_size, meeting_type, name, email, phone, date, time, created_at, status)
-      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+      INSERT INTO bookings (id, service, group_size, meeting_type, location, name, email, phone, date, time, created_at, status)
+      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
       RETURNING *
     `
     const values = [
@@ -74,6 +81,7 @@ export async function POST(request: NextRequest) {
       booking.service,
       booking.groupSize,
       booking.meetingType,
+      booking.meetingType === 'in-person' ? booking.location : null,
       booking.name,
       booking.email,
       booking.phone,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -215,11 +215,11 @@ export default function BookingPage() {
 
                 <button
                   className={`w-full p-4 border-2 rounded-lg text-left hover:border-blue-500 transition-colors ${
-                    formData.meetingType === 'physical'
+                    formData.meetingType === 'in-person'
                       ? 'border-blue-500 bg-blue-50'
                       : 'border-gray-200'
                   }`}
-                  onClick={() => setFormData({...formData, meetingType: 'physical'})}
+                  onClick={() => setFormData({...formData, meetingType: 'in-person'})}
                 >
                   <div className="flex items-center">
                     <MapPin className="mr-3" size={24} />
@@ -230,7 +230,7 @@ export default function BookingPage() {
                   </div>
                 </button>
 
-                {formData.meetingType === 'physical' && (
+                {formData.meetingType === 'in-person' && (
                   <div className="mt-4">
                     <label className="block text-sm font-medium text-gray-700 mb-2">
                       Location
@@ -255,7 +255,7 @@ export default function BookingPage() {
                 </button>
                 <button
                   className="bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700 disabled:opacity-50"
-                  disabled={!formData.meetingType || (formData.meetingType === 'physical' && !formData.location)}
+                  disabled={!formData.meetingType || (formData.meetingType === 'in-person' && !formData.location)}
                   onClick={() => setStep(4)}
                 >
                   Next
@@ -359,7 +359,7 @@ export default function BookingPage() {
                 <div className="space-y-2 text-sm">
                   <p><strong>Service:</strong> {formData.service}</p>
                   <p><strong>Attendees:</strong> {formData.groupSize} people</p>
-                  <p><strong>Type:</strong> {formData.meetingType === 'online' ? 'Online Meeting' : `In-Person at ${formData.location}`}</p>
+                <p><strong>Type:</strong> {formData.meetingType === 'online' ? 'Online Meeting' : `In-Person at ${formData.location}`}</p>
                   <p><strong>Contact:</strong> {formData.name} ({formData.email})</p>
                   <p><strong>Date & Time:</strong> {formData.date} at {formData.time}</p>
                 </div>


### PR DESCRIPTION
## Summary
- persist meeting location in bookings table
- require location when meeting type is in-person and store value
- allow selecting "in-person" meetings in UI

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c2d4fb14d88333bb113d5811419fa7