### PR TITLE
feat: add calendar button to booking email

### DIFF
--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -35,6 +35,19 @@ export async function sendBookingEmail(booking: BookingRecord) {
       ? 'Online Meeting'
       : `In-Person at ${booking.location ?? ''}`
 
+  const start = new Date(`${booking.date}T${booking.time}:00+03:00`)
+  const end = new Date(start.getTime() + 60 * 60 * 1000)
+  const formatDate = (date: Date) =>
+    date.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z'
+  const dates = `${formatDate(start)}/${formatDate(end)}`
+  const details = `Booking ID: ${booking.id}\nName: ${booking.name}\nEmail: ${booking.email}\nPhone: ${booking.phone}\nGroup Size: ${booking.groupSize}\nMeeting Type: ${locationInfo}`
+  const location = booking.meetingType === 'online' ? 'Online' : booking.location ?? ''
+  const calendarUrl = `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(
+    booking.service
+  )}&dates=${dates}&details=${encodeURIComponent(details)}&location=${encodeURIComponent(
+    location
+  )}`
+
   const html = `
     <h2>New Booking Confirmation</h2>
     <p><strong>Booking ID:</strong> ${booking.id}</p>
@@ -45,6 +58,9 @@ export async function sendBookingEmail(booking: BookingRecord) {
     <p><strong>Name:</strong> ${booking.name}</p>
     <p><strong>Email:</strong> ${booking.email}</p>
     <p><strong>Phone:</strong> ${booking.phone}</p>
+    <p style="margin-top:20px;">
+      <a href="${calendarUrl}" style="display:inline-block;padding:10px 20px;background-color:#1a73e8;color:#ffffff;text-decoration:none;border-radius:4px;" target="_blank" rel="noopener noreferrer">Confirm & Save to Calendar</a>
+    </p>
   `
 
   try {


### PR DESCRIPTION
## Summary
- generate Google Calendar link for new bookings
- add "Confirm & Save to Calendar" button in booking confirmation email

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Next lint prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e177c19483339db357715b92c891