### PR TITLE
Add maintenance mode notice page

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,18 @@
 import React from 'react'
 import './globals.css'
 import { Inter } from 'next/font/google'
+import MaintenanceNotice from '../components/MaintenanceNotice'
 
 const inter = Inter({ subsets: ['latin'] })
 
+const isMaintenanceMode = ['true', '1'].includes(
+  (process.env.MAINTENANCE_MODE ?? '').toString().trim().toLowerCase()
+)
+
 export const metadata = {
   title: 'Book Tibenkana - Professional Business Advisory',
-  description: 'Book appointments with Denis Tibenkana for business advisory, product development, and entrepreneurship services',
+  description:
+    'Book appointments with Denis Tibenkana for business advisory, product development, and entrepreneurship services',
   icons: {
     icon: 'https://tibenkana.org/storage/denis-logo-2.png',
     shortcut: 'https://tibenkana.org/storage/denis-logo-2.png',
@@ -21,7 +27,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        {isMaintenanceMode ? <MaintenanceNotice /> : children}
+      </body>
     </html>
   )
 }

--- a/src/components/MaintenanceNotice.tsx
+++ b/src/components/MaintenanceNotice.tsx
@@ -1,0 +1,27 @@
+import { CalendarX2 } from 'lucide-react'
+
+export default function MaintenanceNotice() {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-gray-50 via-white to-blue-50 flex items-center justify-center py-16 px-4">
+      <div className="max-w-xl w-full text-center">
+        <div className="flex justify-center mb-8">
+          <div className="p-6 rounded-full bg-blue-100 shadow-inner">
+            <CalendarX2 className="text-blue-600" size={64} strokeWidth={1.5} />
+          </div>
+        </div>
+        <h1 className="text-4xl font-bold text-gray-800 mb-4">
+          Scheduled Maintenance
+        </h1>
+        <p className="text-lg text-gray-600 leading-relaxed mb-6">
+          This service from Tibenkana Denis is currently down. Please check back later.
+        </p>
+        <div className="bg-white border border-blue-100 rounded-xl shadow-md p-6">
+          <p className="text-base text-gray-500">
+            Our booking calendar is being refreshed to serve you better. We appreciate your
+            patience and look forward to helping you schedule your next consultation soon.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a branded maintenance notice component with calendar visuals
- update the root layout to display the maintenance notice whenever MAINTENANCE_MODE is set to TRUE or 1

## Testing
- npm run lint *(fails: requires interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68cd0d5001fc8333b655e106728e49fa